### PR TITLE
Make log drivers optional features, enabled by default.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: test
+      - name: Test (default features)
         run: cargo test
+      - name: Test (cloudwatch only)
+        run: cargo test --no-default-features --features cloudwatch
+      - name: Test (loki only)
+        run: cargo test --no-default-features --features loki

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,11 @@ name = "vercel-log-drain"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["cloudwatch", "loki"]
+cloudwatch = ["dep:aws-config", "dep:aws-sdk-cloudwatchlogs"]
+loki = ["dep:reqwest"]
+
 [lints.clippy]
 needless_return = "allow"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,14 +15,13 @@ needless_return = "allow"
 [dependencies]
 anyhow = "1.0.79"
 async-trait = "0.1.81"
-aws-config = "1.1.8"
-aws-sdk-cloudwatchlogs = "1.16.0"
+aws-config = { version = "1.1.8", optional = true }
+aws-sdk-cloudwatchlogs = { version = "1.16.0", optional = true }
 axum = { version = "0.7.5", features = ["tracing"] }
 axum-extra = { version = "0.9.2", features = ["typed-header"] }
 axum-prometheus = "0.7.0"
 clap = { version = "4.4.18", features = ["derive", "env"] }
 hex = "0.4.3"
-reqwest = { version = "0.12.7", default-features = false, features = ["json", "rustls-tls", "charset"] }
 ring = "0.17.7"
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.112"
@@ -25,3 +29,10 @@ tokio = { version = "1.35.1", features = ["full"] }
 tower = "0.5.0"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["json"] }
+
+[dependencies.reqwest]
+# Used by loki driver
+optional = true
+version = "0.12.7"
+default-features = false
+features = ["json", "rustls-tls", "charset"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
 ARG RUST_VERSION=1.80.0
+ARG BUILD_ARGS=""
 
-FROM rust:${RUST_VERSION}-slim-bookworm as builder
+FROM rust:${RUST_VERSION}-slim-bookworm AS builder
 WORKDIR /app
-COPY . .
+COPY Cargo.lock Cargo.toml /app/
+COPY src /app/src/
+ARG BUILD_ARGS
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
-    cargo build --release && \
-    cp ./target/release/vercel-log-drain /vercel-log-drain
+<<EOF
+#!/bin/sh
+set -eux
+cargo build --release ${BUILD_ARGS}
+cp ./target/release/vercel-log-drain /vercel-log-drain
+EOF
 
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A simple log-drain you can deploy to export log messages from Vercel to one or m
 
 ### AWS Cloudwatch
 
+> *Available with the `cloudwatch` [feature](#cargo-features) (enabled by default).*
+
 To use the CloudWatch driver, you'll need to either:
 
 - add a environment variable for `VERCEL_LOG_DRAIN_CLOUDWATCH_ENABLED=true`
@@ -65,7 +67,9 @@ data "aws_iam_policy_document" "vercel_log_drain_permissions" {
 
 ### [Grafana Loki](https://grafana.com/docs/loki/latest/)
 
-to use the loki driver, you'll need to set up:
+> *Available with the `loki` [feature](#cargo-features) (enabled by default).*
+
+To use the loki driver, you'll need to set up:
 
 - `--loki-enabled` (or the env var `VERCEL_LOG_DRAIN_LOKI_ENABLED=true`)
 - `--loki-url` (or the env var `VERCEL_LOG_DRAIN_LOKI_URL`)
@@ -105,6 +109,31 @@ If you have structured JSON logging ie the contents of `messaage` is a json stri
 Example: `{ "message": { "method": "GET" } }` vs `{ "message": "{ \"method\": \"GET\" }" }`
 
 This helps with log queries in cloudwatch or if modified your downsteam system to search or filter on data not just provided by vercel but also your own JSON logging in the deployed application.
+
+## Cargo features
+
+`cargo` will build `vercel-log-drain` with **all**
+[features](https://doc.rust-lang.org/cargo/reference/features.html) by default:
+
+Feature      | Description
+------------ | --------
+`cloudwatch` | [AWS Cloudwatch](#aws-cloudwatch) driver
+`loki`       | [Grafana Loki](#grafana-loki) driver
+
+If you want a smaller binary, you could disable all of them with
+`--no-default-features`, and then only re-enable the features you use.
+
+For example, to build `vercel-log-drain` with only AWS Cloudwatch support:
+
+```sh
+cargo build --release --no-default-features --features cloudwatch
+```
+
+This can also be used when building the Docker image:
+
+```sh
+docker build -t vercel-log-drain --build-arg 'BUILD_ARGS=--no-default-features --features cloudwatch' .
+```
 
 ## Testing
 

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -1,5 +1,9 @@
+#[cfg(feature = "cloudwatch")]
 mod cloudwatch;
+#[cfg(feature = "loki")]
 mod loki;
 
+#[cfg(feature = "cloudwatch")]
 pub use cloudwatch::CloudWatchDriver;
+#[cfg(feature = "loki")]
 pub use loki::LokiDriver;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,9 @@ use tokio::sync::mpsc;
 use tracing::{debug, info, Level};
 
 #[cfg(not(any(feature = "cloudwatch", feature = "loki")))]
-compile_error!("No log driver features enabled. Build with the `cloudwatch` and/or `loki` features.");
+compile_error!(
+    "No log driver features enabled. Build with the `cloudwatch` and/or `loki` features."
+);
 
 #[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod drivers;
 mod handlers;
 mod types;
 
-use crate::drivers::{CloudWatchDriver, LokiDriver};
+use crate::drivers::*;
 use crate::types::LogDriver;
 use axum::routing::get;
 use axum_prometheus::PrometheusMetricLayerBuilder;
@@ -13,6 +13,9 @@ use ring::hmac;
 use tokio::signal::{unix, unix::SignalKind};
 use tokio::sync::mpsc;
 use tracing::{debug, info, Level};
+
+#[cfg(not(any(feature = "cloudwatch", feature = "loki")))]
+compile_error!("No log driver features enabled. Build with the `cloudwatch` and/or `loki` features.");
 
 #[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]
@@ -34,15 +37,20 @@ struct Args {
     #[arg(long, env = "VERCEL_LOG_DRAIN_METRICS_PREFIX", default_value = "drain")]
     metrics_prefix: String,
 
+    #[cfg(feature = "cloudwatch")]
     #[arg(long, env = "VERCEL_LOG_DRAIN_ENABLE_CLOUDWATCH")]
     enable_cloudwatch: bool,
 
+    #[cfg(feature = "loki")]
     #[arg(long, env = "VERCEL_LOG_DRAIN_ENABLE_LOKI")]
     enable_loki: bool,
+    #[cfg(feature = "loki")]
     #[arg(long, env = "VERCEL_LOG_DRAIN_LOKI_URL", default_value = "")]
     loki_url: String,
+    #[cfg(feature = "loki")]
     #[arg(long, env = "VERCEL_LOG_DRAIN_LOKI_USER", default_value = "")]
     loki_basic_auth_user: String,
+    #[cfg(feature = "loki")]
     #[arg(long, env = "VERCEL_LOG_DRAIN_LOKI_PASS", default_value = "")]
     loki_basic_auth_pass: String,
 }
@@ -59,6 +67,7 @@ async fn main() -> anyhow::Result<()> {
 
     let mut drivers: Vec<Box<dyn LogDriver>> = Vec::new();
 
+    #[cfg(feature = "cloudwatch")]
     if args.enable_cloudwatch {
         let config = aws_config::load_defaults(aws_config::BehaviorVersion::v2024_03_28()).await;
         let cwl_client = aws_sdk_cloudwatchlogs::Client::new(&config);
@@ -66,6 +75,7 @@ async fn main() -> anyhow::Result<()> {
         debug!("added cloudwatch driver");
     }
 
+    #[cfg(feature = "loki")]
     if args.enable_loki {
         drivers.push(Box::new(LokiDriver::new(
             args.loki_url,


### PR DESCRIPTION
This splits each of the log drivers into Cargo features (`cloudwatch`, `loki`), and plumbs those settings through the `Dockerfile`.

All features are enabled by default for compatibility and convenience. Disabling all features without enabling one of the log drivers results in a compile-time error.

Building with less features has a significant impact on binary size. For release builds on `aarch64-unknown-linux-gnu`:

* default binary with all features: 20 MiB
* `cloudwatch` only: 18 MiB
* `loki` only: 8.3 MiB

`x86_64-unknown-linux-gnu` has similar deltas.
