### PR TITLE
Add Vercel's test requests to test suite, handle their missing `projectName` field

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -20,6 +20,7 @@ mod tests {
 
     #[tokio::test]
     async fn health_check() -> Result<()> {
+        let _ = tracing_subscriber::fmt().json().try_init();
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<types::Message>();
         let state = types::AppState {
             vercel_verify: String::from(""),
@@ -42,6 +43,7 @@ mod tests {
     }
     #[tokio::test]
     async fn root_check() -> Result<()> {
+        let _ = tracing_subscriber::fmt().json().try_init();
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<types::Message>();
         let state = types::AppState {
             vercel_verify: String::from(""),
@@ -65,12 +67,18 @@ mod tests {
     }
     #[tokio::test]
     async fn ingest_check_samples() -> Result<()> {
+        let _ = tracing_subscriber::fmt().json().try_init();
         let test_data = vec![
             include_str!("fixtures/sample_1.json"),
             include_str!("fixtures/sample_2.json"),
             include_str!("fixtures/sample_3.json"),
             include_str!("fixtures/sample_4.json"),
             include_str!("fixtures/sample_5.json"),
+            // Vercel's test requests, missing projectName field
+            include_str!("fixtures/test_build.json"),
+            include_str!("fixtures/test_edge.json"),
+            include_str!("fixtures/test_lambda.json"),
+            include_str!("fixtures/test_static.json"),
         ];
 
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<types::Message>();
@@ -107,11 +115,12 @@ mod tests {
             );
             assert_eq!(response.status(), StatusCode::OK);
         }
-        assert_eq!(rx.len(), 8);
+        assert_eq!(rx.len(), 14);
         return Ok(());
     }
     #[tokio::test]
     async fn ingest_check_structured_messages() -> Result<()> {
+        let _ = tracing_subscriber::fmt().json().try_init();
         let test_data = vec![
             include_str!("fixtures/structured_message_1.json"),
             include_str!("fixtures/structured_message_2.json"),

--- a/src/drivers/cloudwatch.rs
+++ b/src/drivers/cloudwatch.rs
@@ -176,7 +176,11 @@ impl LogDriver for CloudWatchDriver {
 
     async fn send_log(&mut self, message: &Message) -> Result<()> {
         let mut retries: usize = 0;
-        let group_name = format!("/vercel/{}/{}", message.project_name, message.source);
+        let project_name = match &message.project_name {
+            Some(n) => n.as_str(),
+            None => "null",
+        };
+        let group_name = format!("/vercel/{project_name}/{}", message.source);
         #[allow(clippy::useless_format)]
         let stream_name = format!("{}", message.deployment_id);
         self.check_or_create(&group_name, &stream_name).await?;

--- a/src/fixtures/test_build.json
+++ b/src/fixtures/test_build.json
@@ -1,0 +1,26 @@
+[
+    {
+        "id": "1669188564156008676158000000",
+        "message": "SAMPLE MESSAGE: info  - Compiled successfully",
+        "timestamp": 1725343693336,
+        "type": "stdout",
+        "projectId": "prj_xxxxxxxxxxxxxxxxxxxxxx",
+        "deploymentId": "dpl_xxxxxxxxxxxxxxxxxxxxxx",
+        "source": "build",
+        "buildId": "bld_xxxxx",
+        "host": "my-app.vercel.sh",
+        "entrypoint": "."
+    },
+    {
+        "id": "1669188564157008676158000000",
+        "message": "SAMPLE MESSAGE: info  - Collecting page data...",
+        "timestamp": 1725343693336,
+        "type": "stdout",
+        "projectId": "prj_xxxxxxxxxxxxxxxxxxxxxx",
+        "deploymentId": "dpl_xxxxxxxxxxxxxxxxxxxxxx",
+        "source": "build",
+        "buildId": "bld_xxxxx",
+        "host": "my-app.vercel.sh",
+        "entrypoint": "."
+    }
+]

--- a/src/fixtures/test_edge.json
+++ b/src/fixtures/test_edge.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "1669188782687374643267100000",
+    "message": "SAMPLE MESSAGE: Inside middleware hello",
+    "timestamp": 1725343693334,
+    "type": "stdout",
+    "requestId": "xxxxx-xxxxxxxxxxxxx-xxxxxxxxxxxx",
+    "projectId": "prj_xxxxxxxxxxxxxxxxxxxxxx",
+    "deploymentId": "dpl_xxxxxxxxxxxxxxxxxxxxxx",
+    "source": "edge",
+    "host": "my-app.vercel.sh",
+    "path": "/api/hello"
+  },
+  {
+    "id": "1669188782687374643267100001",
+    "message": "SAMPLE MESSAGE: Inside middleware 2",
+    "timestamp": 1725343693334,
+    "type": "stdout",
+    "requestId": "xxxxx-xxxxxxxxxxxxx-xxxxxxxxxxxx",
+    "projectId": "prj_xxxxxxxxxxxxxxxxxxxxxx",
+    "deploymentId": "dpl_xxxxxxxxxxxxxxxxxxxxxx",
+    "source": "edge",
+    "host": "my-app.vercel.sh",
+    "path": "/api/hello"
+  }
+]

--- a/src/fixtures/test_lambda.json
+++ b/src/fixtures/test_lambda.json
@@ -1,0 +1,29 @@
+[
+    {
+        "id": "1669118385998052846361484418",
+        "message": "SAMPLE MESSAGE: START RequestId: xxxxxxxxxxxxxxxxx Version: $LATEST\\\\nEND RequestId: xxxxxxxxxxxxxxxxx\\\\nREPORT RequestId: xxxxxxxxxxxxxxxxx\\\\tDuration: 1472.20 ms\\\\tBilled Duration: 1473 ms\\\\tMemory Size: 1024 MB\\\\tMax Memory Used: 147 MB\\\\t\\\\n",
+        "timestamp": 1725343693335,
+        "requestId": "cdg1::iad1::xxxxx-xxxxxxxxxxxxx-xxxxxxxxxxxx",
+        "statusCode": 200,
+        "proxy": {
+            "timestamp": 1725343693335,
+            "region": "cdg1",
+            "method": "GET",
+            "vercelCache": "MISS",
+            "statusCode": 200,
+            "referer": "https://my-app.vercel.app",
+            "path": "/api/hello",
+            "host": "my-app.vercel.app",
+            "scheme": "https",
+            "clientIp": "xx.xx.xx.xx",
+            "userAgent": [
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36"
+            ]
+        },
+        "projectId": "prj_xxxxxxxxxxxxxxxxxxxxxx",
+        "deploymentId": "dpl_xxxxxxxxxxxxxxxxxxxxxx",
+        "source": "lambda",
+        "host": "my-app.vercel.app",
+        "path": "api/hello"
+    }
+]

--- a/src/fixtures/test_static.json
+++ b/src/fixtures/test_static.json
@@ -1,0 +1,28 @@
+[
+    {
+        "id": "1669188608031840836235986361",
+        "timestamp": 1725343693333,
+        "requestId": "dub1:dub1::xxxxx-xxxxxxxxxxxxx-xxxxxxxxxxxx",
+        "message": "SAMPLE MESSAGE",
+        "proxy": {
+            "timestamp": 1725343693333,
+            "region": "dub1",
+            "method": "GET",
+            "vercelCache": "MISS",
+            "statusCode": 200,
+            "referer": "https://my-app.vercel.app",
+            "path": "/test.txt",
+            "host": "my-app.vercel.app",
+            "scheme": "https",
+            "clientIp": "xxx.xxx.xxx.xxx",
+            "userAgent": [
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36"
+            ]
+        },
+        "projectId": "prj_xxxxxxxxxxxxxxxxxxxxxx",
+        "deploymentId": "dpl_xxxxxxxxxxxxxxxxxxxxxx",
+        "source": "static",
+        "host": "my-app.vercel.sh",
+        "path": "/test.txt"
+    }
+]

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,6 +14,7 @@ pub struct AppState {
 pub struct VercelPayload(pub Vec<Message>);
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct Message {
     pub id: String,
     #[serde(deserialize_with = "deserialize_message_data")]
@@ -23,18 +24,14 @@ pub struct Message {
     #[serde(rename = "type")]
     pub output_type: Option<String>,
     pub source: String,
-    #[serde(rename = "projectName")]
-    pub project_name: String,
-    #[serde(rename = "projectId")]
+    // projectName is not set on the test payload
+    pub project_name: Option<String>,
     pub project_id: String,
-    #[serde(rename = "deploymentId")]
     pub deployment_id: String,
-    #[serde(rename = "buildId")]
     pub build_id: Option<String>,
     pub host: String,
     pub path: Option<String>,
     pub entrypoint: Option<String>,
-    #[serde(rename = "requestId")]
     pub request_id: Option<String>,
     #[allow(private_interfaces)]
     pub proxy: Option<VercelProxy>,
@@ -59,22 +56,18 @@ where
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 struct VercelProxy {
     timestamp: i64,
     method: String,
     scheme: String,
     host: String,
-    #[serde(rename = "userAgent")]
     user_agent: Vec<String>,
     referer: Option<String>,
-    #[serde(rename = "statusCode")]
     status_code: Option<isize>,
-    #[serde(rename = "clientIp")]
     client_ip: String,
     region: String,
-    #[serde(rename = "cacheId")]
     cache_id: Option<String>,
-    #[serde(rename = "vercelCache")]
     vercel_cache: Option<String>,
 }
 
@@ -94,6 +87,11 @@ mod test {
             include_str!("fixtures/sample_3.json"),
             include_str!("fixtures/sample_4.json"),
             include_str!("fixtures/sample_5.json"),
+            // Vercel's test requests, missing projectName field
+            include_str!("fixtures/test_build.json"),
+            include_str!("fixtures/test_edge.json"),
+            include_str!("fixtures/test_lambda.json"),
+            include_str!("fixtures/test_static.json"),
         ];
         for data in test_data {
             let result = serde_json::from_str::<super::VercelPayload>(data);


### PR DESCRIPTION
As discussed in #8, this makes the `projectName` field optional, so that Vercel's test requests can be logged.

This also makes the Vercel types use `#[serde(rename_all = "camelCase")]`, so that we don't need `#[serde(rename = ...)]` everywhere.