### PR TITLE
The big refactor/fix branch

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,11 +1,11 @@
 use crate::{handlers, types};
 
 pub fn create_app(state: types::AppState) -> axum::Router {
-    return axum::Router::new()
+    axum::Router::new()
         .route("/", axum::routing::post(handlers::root))
         .route("/health", axum::routing::get(handlers::health_check))
         .route("/vercel", axum::routing::post(handlers::ingest))
-        .with_state(state);
+        .with_state(state)
 }
 
 #[cfg(test)]
@@ -22,44 +22,34 @@ mod tests {
     async fn health_check() -> Result<()> {
         let _ = tracing_subscriber::fmt().json().try_init();
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<types::Message>();
-        let state = types::AppState {
-            vercel_verify: String::from(""),
-            vercel_secret: ring::hmac::Key::new(
-                ring::hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
-                "".as_bytes(),
-            ),
-            log_queue: tx,
-        };
+        let state = types::AppState::new(
+            "",
+            ring::hmac::Key::new(ring::hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY, b""),
+            tx,
+        )?;
         let mut app = create_app(state);
 
-        let request = Request::builder()
-            .uri("/health")
-            .body(Body::empty())
-            .unwrap();
+        let request = Request::builder().uri("/health").body(Body::empty())?;
         let response = app.as_service().call(request).await?;
 
         assert_eq!(response.status(), StatusCode::OK);
-        return Ok(());
+        Ok(())
     }
     #[tokio::test]
     async fn root_check() -> Result<()> {
         let _ = tracing_subscriber::fmt().json().try_init();
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<types::Message>();
-        let state = types::AppState {
-            vercel_verify: String::from(""),
-            vercel_secret: ring::hmac::Key::new(
-                ring::hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
-                "".as_bytes(),
-            ),
-            log_queue: tx,
-        };
+        let state = types::AppState::new(
+            "",
+            ring::hmac::Key::new(ring::hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY, b""),
+            tx,
+        )?;
         let mut app = create_app(state);
 
         let request = Request::builder()
             .method("POST")
             .uri("/")
-            .body(Body::empty())
-            .unwrap();
+            .body(Body::empty())?;
         let response = app.as_service().call(request).await?;
 
         assert_eq!(response.status(), StatusCode::OK);
@@ -68,7 +58,7 @@ mod tests {
     #[tokio::test]
     async fn ingest_check_samples() -> Result<()> {
         let _ = tracing_subscriber::fmt().json().try_init();
-        let test_data = vec![
+        let test_data = [
             include_str!("fixtures/sample_1.json"),
             include_str!("fixtures/sample_2.json"),
             include_str!("fixtures/sample_3.json"),
@@ -84,14 +74,10 @@ mod tests {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<types::Message>();
         let key = ring::hmac::Key::new(
             ring::hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
-            "deadbeef1234dacb4321".as_bytes(),
+            b"deadbeef1234dacb4321",
         );
 
-        let state = types::AppState {
-            vercel_verify: String::from("test"),
-            vercel_secret: key.clone(),
-            log_queue: tx,
-        };
+        let state = types::AppState::new("test", key.clone(), tx)?;
         let mut app = create_app(state);
         let mut app_service = app.as_service();
 
@@ -101,27 +87,25 @@ mod tests {
                 .method("POST")
                 .header("x-vercel-signature", hex::encode(sig.as_ref()))
                 .uri("/vercel")
-                .body(Body::from(data))
-                .unwrap();
+                .body(Body::from(data))?;
             let response = app_service.call(request).await?;
             assert_eq!(
                 response
                     .headers()
                     .get("x-vercel-verify")
                     .unwrap()
-                    .to_str()
-                    .unwrap(),
+                    .to_str()?,
                 "test"
             );
             assert_eq!(response.status(), StatusCode::OK);
         }
         assert_eq!(rx.len(), 14);
-        return Ok(());
+        Ok(())
     }
     #[tokio::test]
     async fn ingest_check_structured_messages() -> Result<()> {
         let _ = tracing_subscriber::fmt().json().try_init();
-        let test_data = vec![
+        let test_data = [
             include_str!("fixtures/structured_message_1.json"),
             include_str!("fixtures/structured_message_2.json"),
             include_str!("fixtures/sample_1.json"),
@@ -130,14 +114,10 @@ mod tests {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<types::Message>();
         let key = ring::hmac::Key::new(
             ring::hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
-            "deadbeef1234dacb4321".as_bytes(),
+            b"deadbeef1234dacb4321",
         );
 
-        let state = types::AppState {
-            vercel_verify: String::from("test"),
-            vercel_secret: key.clone(),
-            log_queue: tx,
-        };
+        let state = types::AppState::new("test", key.clone(), tx)?;
         let mut app = create_app(state);
         let mut app_service = app.as_service();
 
@@ -147,21 +127,167 @@ mod tests {
                 .method("POST")
                 .header("x-vercel-signature", hex::encode(sig.as_ref()))
                 .uri("/vercel")
-                .body(Body::from(data))
-                .unwrap();
+                .body(Body::from(data))?;
             let response = app_service.call(request).await?;
             assert_eq!(
                 response
                     .headers()
                     .get("x-vercel-verify")
                     .unwrap()
-                    .to_str()
-                    .unwrap(),
+                    .to_str()?,
                 "test"
             );
             assert_eq!(response.status(), StatusCode::OK);
         }
         assert_eq!(rx.len(), 3);
-        return Ok(());
+        Ok(())
+    }
+
+    /// Test Vercel's verification step.
+    ///
+    /// That doesn't sign the incoming request, but expects a HTTP 200 OK
+    /// response and x-vercel-verify header.
+    #[tokio::test]
+    async fn ingest_verify_step() -> Result<()> {
+        let _ = tracing_subscriber::fmt().json().try_init();
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<types::Message>();
+        let key = ring::hmac::Key::new(
+            ring::hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
+            b"deadbeef1234dacb4321",
+        );
+
+        let state = types::AppState::new("test", key, tx)?;
+        let mut app = create_app(state);
+        let mut app_service = app.as_service();
+        let data = b"[]";
+
+        let test_auth_headers = [
+            // Missing header
+            None,
+            // Valid signature; in case Vercel fix it. :)
+            Some("6e7fbac105ca8e99dd5ed29951b4443fe97f7720"),
+        ];
+
+        for auth_header in test_auth_headers {
+            let mut builder = Request::builder().method("POST").uri("/vercel");
+
+            if let Some(auth_header) = auth_header {
+                builder = builder.header("x-vercel-signature", auth_header);
+            }
+
+            let request = builder.body(Body::from(data.as_ref()))?;
+
+            let response = app_service.call(request).await?;
+            assert_eq!(
+                response.status(),
+                StatusCode::OK,
+                "auth_header: {auth_header:?}"
+            );
+            assert_eq!(
+                response
+                    .headers()
+                    .get("x-vercel-verify")
+                    .expect(&format!(
+                        "missing x-vercel-verify header for auth_header: {auth_header:?}"
+                    ))
+                    .to_str()?,
+                "test",
+                "auth_header: {auth_header:?}"
+            );
+        }
+
+        assert_eq!(rx.len(), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn ingest_invalid_signatures() -> Result<()> {
+        let _ = tracing_subscriber::fmt().json().try_init();
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<types::Message>();
+        let key = ring::hmac::Key::new(
+            ring::hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
+            b"deadbeef1234dacb4321",
+        );
+
+        let state = types::AppState::new("test", key, tx)?;
+        let mut app = create_app(state);
+        let mut app_service = app.as_service();
+        let data = b"[]";
+
+        // Everything here should fail *without* a panic.
+        let test_auth_headers = [
+            Some("a"),
+            Some("aa"),
+            Some("xx"),
+            Some("000044d61091a62c339bdd0fb827afad8d61f556"),
+        ];
+
+        for auth_header in test_auth_headers {
+            let mut builder = Request::builder().method("POST").uri("/vercel");
+
+            if let Some(auth_header) = auth_header {
+                builder = builder.header("x-vercel-signature", auth_header);
+            }
+
+            let request = builder.body(Body::from(data.as_ref()))?;
+
+            let response = app_service.call(request).await?;
+            assert!(
+                response.headers().get("x-vercel-verify").is_none(),
+                "auth_header: {auth_header:?}"
+            );
+            assert_eq!(
+                response.status(),
+                StatusCode::UNAUTHORIZED,
+                "auth_header: {auth_header:?}"
+            );
+        }
+
+        assert_eq!(rx.len(), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn ingest_check_json_error() -> Result<()> {
+        let _ = tracing_subscriber::fmt().json().try_init();
+        let test_data = [
+            "{}",        // Expect an array, not an object
+            "[0, 1, 2]", // Expect an array of Message
+            "[",         // Unclosed tags
+            "{",
+        ];
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<types::Message>();
+        let key = ring::hmac::Key::new(
+            ring::hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
+            b"deadbeef1234dacb4321",
+        );
+
+        let state = types::AppState::new("test", key.clone(), tx)?;
+        let mut app = create_app(state);
+        let mut app_service = app.as_service();
+
+        for data in test_data {
+            let sig = ring::hmac::sign(&key, data.as_bytes());
+            let request = Request::builder()
+                .method("POST")
+                .header("x-vercel-signature", hex::encode(sig.as_ref()))
+                .uri("/vercel")
+                .body(Body::from(data))?;
+            let response = app_service.call(request).await?;
+            assert!(
+                response.headers().get("x-vercel-verify").is_none(),
+                "payload: {data:?}"
+            );
+            assert_eq!(
+                response.status(),
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "payload: {data:?}"
+            );
+        }
+        assert_eq!(rx.len(), 0);
+        Ok(())
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -22,11 +22,7 @@ mod tests {
     async fn health_check() -> Result<()> {
         let _ = tracing_subscriber::fmt().json().try_init();
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<types::Message>();
-        let state = types::AppState::new(
-            "",
-            ring::hmac::Key::new(ring::hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY, b""),
-            tx,
-        )?;
+        let state = types::AppState::new("", b"", tx)?;
         let mut app = create_app(state);
 
         let request = Request::builder().uri("/health").body(Body::empty())?;
@@ -39,11 +35,7 @@ mod tests {
     async fn root_check() -> Result<()> {
         let _ = tracing_subscriber::fmt().json().try_init();
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<types::Message>();
-        let state = types::AppState::new(
-            "",
-            ring::hmac::Key::new(ring::hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY, b""),
-            tx,
-        )?;
+        let state = types::AppState::new("", b"", tx)?;
         let mut app = create_app(state);
 
         let request = Request::builder()
@@ -72,20 +64,18 @@ mod tests {
         ];
 
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<types::Message>();
-        let key = ring::hmac::Key::new(
-            ring::hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
-            b"deadbeef1234dacb4321",
-        );
 
-        let state = types::AppState::new("test", key.clone(), tx)?;
-        let mut app = create_app(state);
+        let state = types::AppState::new("test", b"deadbeef1234dacb4321", tx)?;
+        let mut app = create_app(state.clone());
         let mut app_service = app.as_service();
 
         for data in test_data {
-            let sig = ring::hmac::sign(&key, data.as_bytes());
             let request = Request::builder()
                 .method("POST")
-                .header("x-vercel-signature", hex::encode(sig.as_ref()))
+                .header(
+                    "x-vercel-signature",
+                    state.sign_request_for_test_only(data.as_bytes()),
+                )
                 .uri("/vercel")
                 .body(Body::from(data))?;
             let response = app_service.call(request).await?;
@@ -112,20 +102,18 @@ mod tests {
         ];
 
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<types::Message>();
-        let key = ring::hmac::Key::new(
-            ring::hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
-            b"deadbeef1234dacb4321",
-        );
 
-        let state = types::AppState::new("test", key.clone(), tx)?;
-        let mut app = create_app(state);
+        let state = types::AppState::new("test", b"deadbeef1234dacb4321", tx)?;
+        let mut app = create_app(state.clone());
         let mut app_service = app.as_service();
 
         for data in test_data {
-            let sig = ring::hmac::sign(&key, data.as_bytes());
             let request = Request::builder()
                 .method("POST")
-                .header("x-vercel-signature", hex::encode(sig.as_ref()))
+                .header(
+                    "x-vercel-signature",
+                    state.sign_request_for_test_only(data.as_bytes()),
+                )
                 .uri("/vercel")
                 .body(Body::from(data))?;
             let response = app_service.call(request).await?;
@@ -152,13 +140,9 @@ mod tests {
         let _ = tracing_subscriber::fmt().json().try_init();
 
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<types::Message>();
-        let key = ring::hmac::Key::new(
-            ring::hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
-            b"deadbeef1234dacb4321",
-        );
 
-        let state = types::AppState::new("test", key, tx)?;
-        let mut app = create_app(state);
+        let state = types::AppState::new("test", b"deadbeef1234dacb4321", tx)?;
+        let mut app = create_app(state.clone());
         let mut app_service = app.as_service();
         let data = b"[]";
 
@@ -206,12 +190,8 @@ mod tests {
         let _ = tracing_subscriber::fmt().json().try_init();
 
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<types::Message>();
-        let key = ring::hmac::Key::new(
-            ring::hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
-            b"deadbeef1234dacb4321",
-        );
 
-        let state = types::AppState::new("test", key, tx)?;
+        let state = types::AppState::new("test", b"deadbeef1234dacb4321", tx)?;
         let mut app = create_app(state);
         let mut app_service = app.as_service();
         let data = b"[]";
@@ -260,20 +240,18 @@ mod tests {
         ];
 
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<types::Message>();
-        let key = ring::hmac::Key::new(
-            ring::hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
-            b"deadbeef1234dacb4321",
-        );
 
-        let state = types::AppState::new("test", key.clone(), tx)?;
-        let mut app = create_app(state);
+        let state = types::AppState::new("test", b"deadbeef1234dacb4321", tx)?;
+        let mut app = create_app(state.clone());
         let mut app_service = app.as_service();
 
         for data in test_data {
-            let sig = ring::hmac::sign(&key, data.as_bytes());
             let request = Request::builder()
                 .method("POST")
-                .header("x-vercel-signature", hex::encode(sig.as_ref()))
+                .header(
+                    "x-vercel-signature",
+                    state.sign_request_for_test_only(data.as_bytes()),
+                )
                 .uri("/vercel")
                 .body(Body::from(data))?;
             let response = app_service.call(request).await?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -188,7 +188,7 @@ mod tests {
                 response
                     .headers()
                     .get("x-vercel-verify")
-                    .expect(&format!(
+                    .unwrap_or_else(|| panic!(
                         "missing x-vercel-verify header for auth_header: {auth_header:?}"
                     ))
                     .to_str()?,

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -25,12 +25,6 @@ pub async fn ingest(
     debug!("received payload");
 
     let Some(sig_header) = headers.get("x-vercel-signature") else {
-        // Vercel's verification request isn't signed, even if you set a custom
-        // secret in advance. It also expect 200 OK.
-        //
-        // Configure Vercel to send a random custom static header and
-        // configure your HTTPS load balancer in front of vercel-log-drain
-        // to require it, if you want to discard bot traffic.
         warn!(?headers, "received payload without signature");
         counter!("drain_recv_missing_signature").increment(1);
         return state.ok_response();
@@ -86,5 +80,5 @@ pub async fn ingest(
         }
     }
 
-    state.ok_response()
+    return state.ok_response();
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,23 +1,20 @@
 use crate::types;
 use axum::{
-    body::{Body, Bytes},
+    body::Bytes,
     extract::State,
-    http::{header::HeaderMap, Response, StatusCode},
+    http::{header::HeaderMap, StatusCode},
     response::IntoResponse,
 };
 use axum_prometheus::metrics::counter;
-use ring::hmac;
+use core::str;
 use tracing::{debug, error, warn};
 
 pub async fn root() -> impl IntoResponse {
-    Response::builder()
-        .status(StatusCode::OK)
-        .body(Body::empty())
-        .unwrap()
+    StatusCode::OK
 }
 
 pub async fn health_check() -> impl IntoResponse {
-    return StatusCode::OK;
+    StatusCode::OK
 }
 
 pub async fn ingest(
@@ -27,45 +24,51 @@ pub async fn ingest(
 ) -> impl IntoResponse {
     debug!("received payload");
 
-    let signature = match headers.get("x-vercel-signature") {
-        Some(signature) => signature.to_str().unwrap(),
-        None => {
-            warn!("received payload without signature");
-            counter!("drain_recv_invalid_signature").increment(1);
-            // Vercel's verificaion request doesn't actually sign the request,
-            // even if you set a custom secret in advance.
-            return Response::builder()
-                .status(StatusCode::OK)
-                .body(Body::empty())
-                .expect("Defined Responses to be infalliable.");
-        }
+    let Some(sig_header) = headers.get("x-vercel-signature") else {
+        // Vercel's verification request isn't signed, even if you set a custom
+        // secret in advance. It also expect 200 OK.
+        //
+        // Configure Vercel to send a random custom static header and
+        // configure your HTTPS load balancer in front of vercel-log-drain
+        // to require it, if you want to discard bot traffic.
+        warn!(?headers, "received payload without signature");
+        counter!("drain_recv_missing_signature").increment(1);
+        return state.ok_response();
     };
-    let body_string = match String::from_utf8(body.to_vec()) {
+
+    // Catch whenever we get a signature header which is not 20 bytes encoded
+    // in base16.
+    let Some(sig_bytes) = sig_header.to_str().ok().and_then(|sig| {
+        let mut sig_bytes = [0; 20];
+        hex::decode_to_slice(sig, &mut sig_bytes)
+            .ok()
+            .map(|()| sig_bytes)
+    }) else {
+        warn!(?headers, "received payload with invalid signature");
+        counter!("drain_recv_invalid_signature").increment(1);
+        return StatusCode::UNAUTHORIZED.into_response();
+    };
+
+    // Catch whenever the signature is invalid.
+    if state.verify_signature(&body, &sig_bytes).is_err() {
+        error!(?headers, "failed verifying signature");
+        counter!("drain_failed_verify_signature").increment(1);
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    // Now that we've verified the signature, decode the payload as a UTF-8
+    // string.
+    let body_string = match str::from_utf8(&body) {
         Ok(body_string) => body_string,
         Err(e) => {
-            error!("received bad utf-8: {:?}", e);
+            error!("received bad utf-8: {e:?}");
             counter!("drain_recv_bad_utf8").increment(1);
-            return Response::builder()
-                .status(StatusCode::NOT_ACCEPTABLE)
-                .body(Body::empty())
-                .expect("Defined Responses to be infalliable.");
+            return StatusCode::NOT_ACCEPTABLE.into_response();
         }
     };
-    let mut sig_bytes = [0u8; 20];
-    hex::decode_to_slice(signature, &mut sig_bytes).unwrap();
-    match hmac::verify(&state.vercel_secret, body_string.as_bytes(), &sig_bytes) {
-        Ok(_) => {}
-        Err(e) => {
-            error!("failed verifying signature: {:?}", e);
-            counter!("drain_failed_verify_signature").increment(1);
-            return Response::builder()
-                .status(StatusCode::UNPROCESSABLE_ENTITY)
-                .header("x-vercel-verify", state.vercel_verify)
-                .body(Body::empty())
-                .expect("Defined Responses to be infalliable.");
-        }
-    }
-    match serde_json::from_str::<types::VercelPayload>(&body_string) {
+
+    // Parse the string as JSON.
+    match serde_json::from_str::<types::VercelPayload>(body_string) {
         Ok(payload) => {
             debug!("parsed payload, OK");
             for message in payload.0 {
@@ -79,11 +82,9 @@ pub async fn ingest(
         }
         Err(e) => {
             error!(payload = ?body_string, "failed parsing: {:?}", e);
+            return StatusCode::UNPROCESSABLE_ENTITY.into_response();
         }
     }
-    return Response::builder()
-        .status(StatusCode::OK)
-        .header("x-vercel-verify", state.vercel_verify)
-        .body(Body::empty())
-        .expect("Defined Responses to be infalliable.");
+
+    state.ok_response()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,6 @@ use crate::types::LogDriver;
 use axum::routing::get;
 use axum_prometheus::PrometheusMetricLayerBuilder;
 use clap::Parser;
-use ring::hmac;
 use tokio::signal::{unix, unix::SignalKind};
 use tokio::sync::mpsc;
 use tracing::{debug, info, Level};
@@ -96,10 +95,7 @@ async fn main() -> anyhow::Result<()> {
     });
     let state = types::AppState::new(
         &args.vercel_verify,
-        hmac::Key::new(
-            hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
-            args.vercel_secret.as_bytes(),
-        ),
+        args.vercel_secret.as_bytes(),
         tx,
     )?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,11 +93,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::spawn(async move {
         controller.run().await;
     });
-    let state = types::AppState::new(
-        &args.vercel_verify,
-        args.vercel_secret.as_bytes(),
-        tx,
-    )?;
+    let state = types::AppState::new(&args.vercel_verify, args.vercel_secret.as_bytes(), tx)?;
 
     let listen_address = format!("{}:{}", args.ip, args.port);
     let listener = tokio::net::TcpListener::bind(listen_address.clone()).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,14 +94,14 @@ async fn main() -> anyhow::Result<()> {
     tokio::spawn(async move {
         controller.run().await;
     });
-    let state = types::AppState {
-        vercel_verify: args.vercel_verify,
-        vercel_secret: hmac::Key::new(
+    let state = types::AppState::new(
+        &args.vercel_verify,
+        hmac::Key::new(
             hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
             args.vercel_secret.as_bytes(),
         ),
-        log_queue: tx,
-    };
+        tx,
+    )?;
 
     let listen_address = format!("{}:{}", args.ip, args.port);
     let listener = tokio::net::TcpListener::bind(listen_address.clone()).await?;


### PR DESCRIPTION
Discussed in #8; this has a bunch of refactoring and fixes that are difficult to untangle.

AppState changes:

* Construct an "OK" response with `x-vercel-verify` header on start-up, and store it in the `AppState`, so it can be cloned as needed.

  This avoids needing an `unwrap()` in the ingest handler, that could be triggered with a configuration error but only after the first request.

* Accept `vercel_secret` as a `&[u8]`, and move all the HMAC handling in there.

Ingest handler:

* Respond to ingest requests without a signature with HTTP 200 OK and `x-vercel-verify` header, to match Vercel not sending this header, even when you set a custom secret during setup.

  Added a test case for this and a request with a valid signature but empty payload (in case they fix this).

* Verify the request payload's HMAC before trying to decode it as UTF-8.

* Return Unauthorized error whenever `x-vercel-signature` header is present, and is not in the expected format or doesn't pass HMAC checks, and don't send a `x-vercel-verify` header in those responses.

* Avoid copying the payload by using `str::from_utf8()` on a `&[u8]`, rather than `::to_vec()` and passing it into a `String`.

* Use `IntoResponse::into_response()` to construct responses with empty bodies and no special header.

* Return Unprocessable Entity error whenever it doesn't parse correctly, rather than returning OK.

* Removed many `unwrap()` calls which could crash the binary with a crafted request.

* Added test cases for the expected response codes, and also for some requests that could crash because of `unwrap()`.

Other handlers:

* Make `root()` return a `StatusCode` directly, like `health_check()`.

* Fix needless-returns.

Tests:

* Use `?` operator rather than `unwrap()` where possible.

* Use arrays for constants rather than `vec!`.

* Use `&str` and `b""` for constants where possible.