### PR TITLE
Make `VercelProxy::user_agent` optional, add some missing `Message` fields.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -56,6 +56,7 @@ mod tests {
             include_str!("fixtures/sample_3.json"),
             include_str!("fixtures/sample_4.json"),
             include_str!("fixtures/sample_5.json"),
+            include_str!("fixtures/sample_6.json"),
             // Vercel's test requests, missing projectName field
             include_str!("fixtures/test_build.json"),
             include_str!("fixtures/test_edge.json"),
@@ -89,7 +90,7 @@ mod tests {
             );
             assert_eq!(response.status(), StatusCode::OK);
         }
-        assert_eq!(rx.len(), 14);
+        assert_eq!(rx.len(), 15);
         Ok(())
     }
     #[tokio::test]

--- a/src/fixtures/sample_6.json
+++ b/src/fixtures/sample_6.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "1706327928080727830237235800",
+    "message": "[GET] [middleware: \"middleware\"] / status=200",
+    "timestamp": 1706327928080,
+    "type": "middleware-invocation",
+    "requestId": "abc1-1706327928072-6ecc9b4dfbf3",
+    "executionRegion": "abc1",
+    "statusCode": 200,
+    "level": "info",
+    "proxy": {
+      "timestamp": 1706327928072,
+      "region": "abc1",
+      "clientIp": "192.0.2.3",
+      "method": "GET",
+      "path": "/",
+      "scheme": "https",
+      "host": "example.com"
+    },
+    "projectId": "prj_xxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "projectName": "example",
+    "deploymentId": "dpl_xxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "source": "edge",
+    "host": "example.vercel.app",
+    "path": "middleware",
+    "environment": "production"
+  }
+]

--- a/src/types.rs
+++ b/src/types.rs
@@ -81,6 +81,9 @@ pub struct Message {
     pub request_id: Option<String>,
     #[allow(private_interfaces)]
     pub proxy: Option<VercelProxy>,
+    pub status_code: Option<i16>,
+    pub execution_region: Option<String>,
+    pub level: Option<String>,
 }
 
 fn deserialize_message_data<'de, D>(deserializer: D) -> Result<serde_json::Value, D::Error>
@@ -108,6 +111,7 @@ struct VercelProxy {
     method: String,
     scheme: String,
     host: String,
+    #[serde(default)]
     user_agent: Vec<String>,
     referer: Option<String>,
     status_code: Option<isize>,
@@ -135,6 +139,7 @@ mod test {
             include_str!("fixtures/sample_3.json"),
             include_str!("fixtures/sample_4.json"),
             include_str!("fixtures/sample_5.json"),
+            include_str!("fixtures/sample_6.json"),
             // Vercel's test requests, missing projectName field
             include_str!("fixtures/test_build.json"),
             include_str!("fixtures/test_edge.json"),


### PR DESCRIPTION
* Make `VercelProxy::user_agent` optional, which is missing for `type: middleware-invocation`.
* Add `Message` fields `status_code`, `execution_region` and `level`.
